### PR TITLE
Remove redundant setup in collision test

### DIFF
--- a/tests/test_collision_detection.py
+++ b/tests/test_collision_detection.py
@@ -137,12 +137,7 @@ class TestCollisionDetection:
     def test_map_boundary_collision_circular(self):
         """Test that circular bases cannot move outside map boundaries."""
 
-        # Create test scenario
-        unit = self.create_circular_unit(x=10.0, y=10.0)
-        self.setup_units_on_map([unit])
-
-
-        # Create a clean scenario with just one unit
+        # Create test scenario with a single unit
         unit = self.create_circular_unit(x=24.0, y=36.0)
         self.setup_units_on_map([unit])
         


### PR DESCRIPTION
## Summary
- Simplify boundary collision test by removing unused unit initialization

## Testing
- `pytest tests/test_collision_detection.py::TestCollisionDetection::test_map_boundary_collision_circular -q`


------
https://chatgpt.com/codex/tasks/task_e_68950d5b90e08330a4e9b9f621051a2f