### PR TITLE
[codex] Add parsed datasheet cache and state invalidation

### DIFF
--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -78,6 +78,19 @@ shooting or deployment policy probe.
 
 ## Cache Invalidation
 
-`Map.state_generation` increments when terrain, objectives, or placed units change. Visibility
-cache keys include this generation, and map mutations clear per-map enemy-model collision caches,
-so generated geometry caches do not survive battlefield topology changes.
+`Map.state_generation` increments when battlefield topology changes **and** when runtime state
+changes that affect geometry/rules cache validity:
+
+- model movement (`Model.set_location`)
+- model wounds changing
+- model destruction/removal
+- phase transitions and battle-round advancement
+- command-point changes
+- active stratagem/rule effects that modify runtime legality
+
+Visibility cache keys include this generation, and map mutations clear per-map enemy-model
+collision caches, so generated geometry caches do not survive stale game-state transitions.
+
+Static datasheet parsing now uses immutable cached `ParsedDatasheetRecord` snapshots (composition,
+abilities, keywords, wargear, and options). `Unit` instances consume cloned copies from that cache
+and keep mutable battlefield state locally.

--- a/src/warhammer40k_ai/engine/turn_manager.py
+++ b/src/warhammer40k_ai/engine/turn_manager.py
@@ -47,6 +47,11 @@ def next_phase(game: "Game") -> None:
     current_phase_value = game.phase.value
     next_phase_value = (current_phase_value + 1) % len(BattleRoundPhases)
     game.phase = BattleRoundPhases(next_phase_value)
+    try:
+        if hasattr(game.map, "bump_state_generation"):
+            game.map.bump_state_generation(f"phase_changed:{getattr(game.phase, 'name', game.phase)}")
+    except (AttributeError, TypeError):
+        logger.debug("Unable to bump map state generation for phase change.", exc_info=True)
     if next_phase_value != 0:
         try:
             refresh_csm_fn = getattr(game, "_refresh_csm_tyrannical_motivation_phase_state", None)
@@ -109,6 +114,11 @@ def next_phase(game: "Game") -> None:
             except Exception:
                 pass
             game.turn += 1
+            try:
+                if hasattr(game.map, "bump_state_generation"):
+                    game.map.bump_state_generation("battle_round_advanced")
+            except (AttributeError, TypeError):
+                logger.debug("Unable to bump map state generation for battle-round advance.", exc_info=True)
             game.battle_round_starting_player_index = game.current_player_index  # This player starts the next round
 
             # Reset round state for ALL units at the start of a new battle round

--- a/src/warhammer40k_ai/roster/player_resources.py
+++ b/src/warhammer40k_ai/roster/player_resources.py
@@ -223,6 +223,10 @@ class PlayerResourceMixin:
             "source": source,
         }
         self.cp_history.append(entry)
+        game_map = getattr(game, "map", None) if game is not None else None
+        bump = getattr(game_map, "bump_state_generation", None)
+        if callable(bump):
+            bump("command_points_changed")
 
     def _cp_gain_source_counts_as_ability(
         self,

--- a/src/warhammer40k_ai/units/model.py
+++ b/src/warhammer40k_ai/units/model.py
@@ -118,15 +118,15 @@ class Model:
             fn = getattr(pu, "has_keyword_local", None)
             if callable(fn):
                 return bool(fn("Character"))
-        except Exception:
-            pass
+        except (AttributeError, TypeError, ValueError):
+            logger.debug("Model.is_character failed has_keyword_local lookup.", exc_info=True)
         try:
             if not hasattr(pu, "keywords"):
                 return bool(getattr(pu, "is_character", False))
             kws = getattr(pu, "keywords", []) or []
             return "character" in [str(k).lower() for k in kws]
-        except Exception:
-            pass
+        except (AttributeError, TypeError, ValueError):
+            logger.debug("Model.is_character failed keyword list fallback.", exc_info=True)
         return bool(getattr(pu, "is_character", False))
 
     def has_keyword(self, keyword: str) -> bool:
@@ -147,13 +147,13 @@ class Model:
         try:
             if kw in [k.lower() for k in (self.keywords or [])]:
                 return True
-        except Exception:
-            pass
+        except (AttributeError, TypeError):
+            logger.debug("Model.has_any_keyword failed keywords lookup.", exc_info=True)
         try:
             if kw in [k.lower() for k in (self.faction_keywords or [])]:
                 return True
-        except Exception:
-            pass
+        except (AttributeError, TypeError):
+            logger.debug("Model.has_any_keyword failed faction_keywords lookup.", exc_info=True)
         return False
 
     @property
@@ -2121,10 +2121,13 @@ class Model:
 
     def set_location(self, x: float, y: float, z: float, facing: float) -> None:
         """Set the location and facing of the model."""
+        old_loc = (self.model_base.x, self.model_base.y, self.model_base.z, self.model_base.facing)
         self.model_base.x = x
         self.model_base.y = y
         self.model_base.z = z
         self.model_base.set_facing(facing)
+        if old_loc != (x, y, z, facing):
+            self._bump_parent_map_state_generation("model_moved")
 
     def get_location(self) -> Tuple[float, float, float, float]:
         """Get the location and facing of the model."""
@@ -2591,7 +2594,10 @@ class Model:
 
     @wounds.setter
     def wounds(self, value: int) -> None:
+        old_wounds = getattr(self, "_wounds", None)
         self._wounds = value
+        if old_wounds != value:
+            self._bump_parent_map_state_generation("model_wounds_changed")
 
     @property
     def leadership(self) -> int:
@@ -2803,3 +2809,16 @@ class Model:
 
     def __hash__(self) -> int:
         return hash(self.id)
+
+    def _bump_parent_map_state_generation(self, reason: str) -> None:
+        unit = getattr(self, "parent_unit", None)
+        if unit is None:
+            return
+        get_army = getattr(unit, "get_parent_army", None)
+        army = get_army() if callable(get_army) else getattr(unit, "parent_army", None)
+        player = getattr(army, "player", None)
+        game = getattr(player, "game", None)
+        game_map = getattr(game, "map", None)
+        bump = getattr(game_map, "bump_state_generation", None)
+        if callable(bump):
+            bump(reason)

--- a/src/warhammer40k_ai/units/parsed_datasheet.py
+++ b/src/warhammer40k_ai/units/parsed_datasheet.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from copy import deepcopy
+from threading import Lock
+from typing import Any
+
+FrozenValue = tuple[str, Any]
+
+
+def _freeze_static_value(value: Any) -> FrozenValue:
+    if isinstance(value, dict):
+        return (
+            "dict",
+            tuple((deepcopy(key), _freeze_static_value(item)) for key, item in value.items()),
+        )
+    if isinstance(value, list):
+        return ("list", tuple(_freeze_static_value(item) for item in value))
+    if isinstance(value, tuple):
+        return ("tuple", tuple(_freeze_static_value(item) for item in value))
+    if isinstance(value, set):
+        frozen_items = tuple(
+            sorted((_freeze_static_value(item) for item in value), key=repr)
+        )
+        return ("set", frozen_items)
+    return ("value", deepcopy(value))
+
+
+def _thaw_static_value(value: FrozenValue) -> Any:
+    kind, payload = value
+    if kind == "dict":
+        return {deepcopy(key): _thaw_static_value(item) for key, item in payload}
+    if kind == "list":
+        return [_thaw_static_value(item) for item in payload]
+    if kind == "tuple":
+        return tuple(_thaw_static_value(item) for item in payload)
+    if kind == "set":
+        return {_thaw_static_value(item) for item in payload}
+    if kind == "value":
+        return deepcopy(payload)
+    raise ValueError(f"Unknown frozen static value kind: {kind!r}")
+
+
+@dataclass(frozen=True)
+class ParsedDatasheetRecord:
+    """Immutable parsed datasheet snapshot for static unit construction data."""
+
+    keywords: tuple[str, ...]
+    faction_keywords: tuple[str, ...]
+    unit_composition: FrozenValue
+    unit_composition_options: FrozenValue
+    unit_models_maximum: int | None
+    models_cost: FrozenValue
+    models_cost_addons: FrozenValue
+    possible_wargear: tuple[Any, ...]
+    wargear_options: FrozenValue
+    possible_abilities: tuple[Any, ...]
+    wargear_constraints: FrozenValue
+
+    @classmethod
+    def from_parsed(
+        cls,
+        *,
+        keywords: tuple[str, ...],
+        faction_keywords: tuple[str, ...],
+        unit_composition: dict[str, tuple[int, int]],
+        unit_composition_options: list[dict[str, tuple[int, int]]],
+        unit_models_maximum: int | None,
+        models_cost: dict[Any, int],
+        models_cost_addons: dict[str, int],
+        possible_wargear: list[Any],
+        wargear_options: Any,
+        possible_abilities: list[Any],
+        wargear_constraints: dict[str, Any],
+    ) -> "ParsedDatasheetRecord":
+        return cls(
+            keywords=tuple(keywords),
+            faction_keywords=tuple(faction_keywords),
+            unit_composition=_freeze_static_value(unit_composition),
+            unit_composition_options=_freeze_static_value(unit_composition_options),
+            unit_models_maximum=unit_models_maximum,
+            models_cost=_freeze_static_value(models_cost),
+            models_cost_addons=_freeze_static_value(models_cost_addons),
+            possible_wargear=tuple(deepcopy(list(possible_wargear))),
+            wargear_options=_freeze_static_value(wargear_options),
+            possible_abilities=tuple(deepcopy(list(possible_abilities))),
+            wargear_constraints=_freeze_static_value(wargear_constraints),
+        )
+
+    def clone_unit_composition(self) -> dict[str, tuple[int, int]]:
+        return _thaw_static_value(self.unit_composition)
+
+    def clone_unit_composition_options(self) -> list[dict[str, tuple[int, int]]]:
+        return _thaw_static_value(self.unit_composition_options)
+
+    def clone_models_cost(self) -> dict[str, int]:
+        return _thaw_static_value(self.models_cost)
+
+    def clone_models_cost_addons(self) -> dict[str, int]:
+        return _thaw_static_value(self.models_cost_addons)
+
+    def clone_possible_wargear(self) -> list[Any]:
+        return deepcopy(list(self.possible_wargear))
+
+    def clone_wargear_options(self) -> Any:
+        return _thaw_static_value(self.wargear_options)
+
+    def clone_possible_abilities(self) -> list[Any]:
+        return deepcopy(list(self.possible_abilities))
+
+    def clone_wargear_constraints(self) -> dict[str, Any]:
+        return _thaw_static_value(self.wargear_constraints)
+
+
+_PARSED_DATASHEET_CACHE: dict[str, ParsedDatasheetRecord] = {}
+_PARSED_DATASHEET_CACHE_LOCK = Lock()
+
+
+def get_cached_parsed_datasheet_record(cache_key: str) -> ParsedDatasheetRecord | None:
+    with _PARSED_DATASHEET_CACHE_LOCK:
+        return _PARSED_DATASHEET_CACHE.get(cache_key)
+
+
+def put_cached_parsed_datasheet_record(cache_key: str, record: ParsedDatasheetRecord) -> None:
+    with _PARSED_DATASHEET_CACHE_LOCK:
+        _PARSED_DATASHEET_CACHE[cache_key] = record

--- a/src/warhammer40k_ai/units/unit.py
+++ b/src/warhammer40k_ai/units/unit.py
@@ -1,6 +1,7 @@
 import logging
 from typing import List, Tuple, Optional, Callable
 from typing import TYPE_CHECKING
+import hashlib
 from .model import Model
 from ..utility.model_base import Base, BaseType
 from .wargear import Wargear, WargearOption, parse_option_string, parse_alternate_3
@@ -113,6 +114,11 @@ from .unit_mixins import (
     SelectedToShootMixin,
     LateGameplayMixin,
 )
+from .parsed_datasheet import (
+    ParsedDatasheetRecord,
+    get_cached_parsed_datasheet_record,
+    put_cached_parsed_datasheet_record,
+)
 from .unit_mixins import (
     rules_parsing_mixin as _rules_parsing_mixin,
     datasheet_wargear_mixin as _datasheet_wargear_mixin,
@@ -165,32 +171,122 @@ class Unit(
     SelectedToShootMixin,
     LateGameplayMixin,
 ):
+    @staticmethod
+    def _datasheet_cache_key(datasheet) -> str:
+        datasheet_id = str(getattr(datasheet, "id", "") or "").strip()
+        attrs = getattr(datasheet, "__dict__", None)
+        if isinstance(attrs, dict) and attrs:
+            payload_source = tuple((str(key), attrs[key]) for key in sorted(attrs))
+        else:
+            payload_source = (
+                ("name", getattr(datasheet, "name", "")),
+                ("faction_id", getattr(datasheet, "faction_id", "")),
+                ("datasheets_unit_composition", getattr(datasheet, "datasheets_unit_composition", [])),
+                ("datasheets_models_cost", getattr(datasheet, "datasheets_models_cost", [])),
+                ("datasheets_wargear", getattr(datasheet, "datasheets_wargear", [])),
+                ("datasheets_options", getattr(datasheet, "datasheets_options", [])),
+                ("datasheets_abilities", getattr(datasheet, "datasheets_abilities", [])),
+                ("keywords", getattr(datasheet, "keywords", [])),
+                ("faction_keywords", getattr(datasheet, "faction_keywords", [])),
+            )
+        payload = repr(payload_source)
+        digest = hashlib.sha1(payload.encode("utf-8")).hexdigest()
+        if datasheet_id:
+            return f"id:{datasheet_id}:{digest}"
+        return f"repr:{digest}"
+
+    def _build_parsed_datasheet_record(
+        self,
+        datasheet,
+        *,
+        unit_composition: dict[str, tuple[int, int]],
+        unit_composition_options: list[dict[str, tuple[int, int]]],
+        unit_models_maximum: int | None,
+        models_cost: dict,
+        models_cost_addons: dict[str, int],
+    ) -> ParsedDatasheetRecord:
+        keywords = tuple(str(v or "") for v in list(getattr(datasheet, "keywords", []) or []))
+        faction_keywords = tuple(str(v or "") for v in list(getattr(datasheet, "faction_keywords", []) or []))
+        possible_wargear = list(getattr(self, "possible_wargear", []) or [])
+        possible_abilities = list(getattr(self, "possible_abilities", []) or [])
+        wargear_constraints = dict(getattr(self, "_wargear_constraints", {}) or {})
+        return ParsedDatasheetRecord.from_parsed(
+            keywords=keywords,
+            faction_keywords=faction_keywords,
+            unit_composition=unit_composition,
+            unit_composition_options=unit_composition_options,
+            unit_models_maximum=unit_models_maximum,
+            models_cost=models_cost,
+            models_cost_addons=models_cost_addons,
+            possible_wargear=possible_wargear,
+            wargear_options=self.wargear_options,
+            possible_abilities=possible_abilities,
+            wargear_constraints=wargear_constraints,
+        )
+
     def __init__(self, datasheet, quantity=None, enhancement=None):
         self._id = str(uuid.uuid4())
         self._datasheet = datasheet
         self.name = datasheet.name
         self.faction = datasheet.faction_data["name"]
-        self.keywords = getattr(datasheet, 'keywords', [])  # Use getattr with a default value
-        self.faction_keywords = getattr(datasheet, 'faction_keywords', [])  # Use getattr with a default value
-        try:
-            self.unit_composition = self._parse_unit_composition(datasheet.datasheets_unit_composition)
-        except (AttributeError, TypeError, ValueError) as exc:
-            raise UnitInitializationError(
-                f"Failed to parse unit composition for {self.name!r}."
-            ) from exc
-        try:
-            self.models_cost = self._parse_models_cost(datasheet.datasheets_models_cost)
-        except Exception as e:
-            #print(f"{self.name} - NEED TO HANDLE - ERROR PARSING MODELS COST: {e}")
-            self.models_cost = { "spawn_on_death": 0 }
-        self.models = self._create_models(datasheet, quantity)
-        self._initialize_horrors_state()
-
-        # Wargear Stuff
-        self.possible_wargear = self._parse_wargear(datasheet)
-        self.wargear_options = []
-        self._parse_wargear_options(datasheet) # this needs to here, sets above variable
-        self.possible_abilities = self._parse_abilities(datasheet)
+        cache_key = self._datasheet_cache_key(datasheet)
+        parsed_record = get_cached_parsed_datasheet_record(cache_key)
+        if parsed_record is None:
+            self.keywords = list(getattr(datasheet, 'keywords', []) or [])
+            self.faction_keywords = list(getattr(datasheet, 'faction_keywords', []) or [])
+            try:
+                self.unit_composition = self._parse_unit_composition(datasheet.datasheets_unit_composition)
+                unit_composition = dict(self.unit_composition)
+                unit_composition_options = [
+                    dict(option)
+                    for option in list(getattr(self, "unit_composition_options", []) or [])
+                ]
+                unit_models_maximum = getattr(self, "unit_models_maximum", None)
+            except (AttributeError, TypeError, ValueError) as exc:
+                raise UnitInitializationError(
+                    f"Failed to parse unit composition for {self.name!r}."
+                ) from exc
+            try:
+                self.models_cost = self._parse_models_cost(datasheet.datasheets_models_cost)
+            except (AttributeError, TypeError, ValueError):
+                self.models_cost = {"spawn_on_death": 0}
+                self.models_cost_addons = {}
+            models_cost = dict(getattr(self, "models_cost", {}) or {})
+            models_cost_addons = dict(getattr(self, "models_cost_addons", {}) or {})
+            self.possible_wargear = self._parse_wargear(datasheet)
+            self.models = self._create_models(datasheet, quantity)
+            self._initialize_horrors_state()
+            self.wargear_options = []
+            self._parse_wargear_options(datasheet)
+            self.possible_abilities = self._parse_abilities(datasheet)
+            parsed_record = self._build_parsed_datasheet_record(
+                datasheet,
+                unit_composition=unit_composition,
+                unit_composition_options=unit_composition_options,
+                unit_models_maximum=unit_models_maximum,
+                models_cost=models_cost,
+                models_cost_addons=models_cost_addons,
+            )
+            put_cached_parsed_datasheet_record(cache_key, parsed_record)
+        else:
+            self.keywords = list(parsed_record.keywords)
+            self.faction_keywords = list(parsed_record.faction_keywords)
+            try:
+                self.unit_composition = parsed_record.clone_unit_composition()
+                self.unit_composition_options = parsed_record.clone_unit_composition_options()
+                self.unit_models_maximum = parsed_record.unit_models_maximum
+            except (AttributeError, TypeError, ValueError) as exc:
+                raise UnitInitializationError(
+                    f"Failed to parse unit composition for {self.name!r}."
+                ) from exc
+            self.models_cost = parsed_record.clone_models_cost()
+            self.models_cost_addons = parsed_record.clone_models_cost_addons()
+            self.possible_wargear = parsed_record.clone_possible_wargear()
+            self.models = self._create_models(datasheet, quantity)
+            self._initialize_horrors_state()
+            self.wargear_options = parsed_record.clone_wargear_options()
+            self._wargear_constraints = parsed_record.clone_wargear_constraints()
+            self.possible_abilities = parsed_record.clone_possible_abilities()
         self.add_wargear()
 
         # Attachments

--- a/src/warhammer40k_ai/units/unit_mixins/damage_death_mixin.py
+++ b/src/warhammer40k_ai/units/unit_mixins/damage_death_mixin.py
@@ -842,6 +842,8 @@ class DamageDeathMixin:
             self.round_state.num_lost_models_this_round += 1
             self.models_lost.append(model)
         self.models.remove(model)
+        if game_map is not None and hasattr(game_map, "bump_state_generation"):
+            game_map.bump_state_generation("model_destroyed")
 
         # Invalidate ability cache since unit composition changed
         self._invalidate_ability_cache()

--- a/src/warhammer40k_ai/units/wargear.py
+++ b/src/warhammer40k_ai/units/wargear.py
@@ -198,10 +198,21 @@ class WargearProfile:
                 # Choose the highest expected value (e.g. Sustained Hits 2 over Sustained Hits 1).
                 try:
                     return max(candidates, key=lambda c: float(c.stat_average()))
-                except Exception:
+                except (TypeError, ValueError):
+                    logger.warning(
+                        "Unable to rank keyword suffix counts for %r on %s; falling back to first candidate.",
+                        prefix,
+                        getattr(self, "name", "<unknown>"),
+                        exc_info=True,
+                    )
                     return candidates[0]
-        except Exception:
-            pass
+        except (AttributeError, TypeError, ValueError):
+            logger.warning(
+                "Failed to parse keyword suffix count for %r on %s; defaulting to 0.",
+                prefix,
+                getattr(self, "name", "<unknown>"),
+                exc_info=True,
+            )
         return Count.from_string("0")
 
     ###########################################################################

--- a/src/warhammer40k_ai/utility/stratagem_effects.py
+++ b/src/warhammer40k_ai/utility/stratagem_effects.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 from typing import Optional
+import logging
 
 from .event_bus import append_action
+
+logger = logging.getLogger(__name__)
 
 
 def _resolve_unit_root(unit) -> Optional[object]:
@@ -10,9 +13,33 @@ def _resolve_unit_root(unit) -> Optional[object]:
         return None
     try:
         root = unit.get_attached_unit_root()
-    except Exception:
+    except AttributeError:
         root = unit
     return root
+
+
+def _bump_effect_generation(root: object, reason: str, *, player: object = None, game: object = None) -> None:
+    if game is not None:
+        game_map = getattr(game, "map", None)
+        bump = getattr(game_map, "bump_state_generation", None)
+        if callable(bump):
+            bump(reason)
+            return
+    if player is not None:
+        game = getattr(player, "game", None)
+        game_map = getattr(game, "map", None)
+        bump = getattr(game_map, "bump_state_generation", None)
+        if callable(bump):
+            bump(reason)
+            return
+    get_army = getattr(root, "get_parent_army", None)
+    army = get_army() if callable(get_army) else getattr(root, "parent_army", None)
+    player = getattr(army, "player", None)
+    game = getattr(player, "game", None)
+    game_map = getattr(game, "map", None)
+    bump = getattr(game_map, "bump_state_generation", None)
+    if callable(bump):
+        bump(reason)
 
 
 def apply_flickering_reality_effect(
@@ -29,12 +56,12 @@ def apply_flickering_reality_effect(
     if player is None:
         try:
             player = root.get_parent_army().player
-        except Exception:
+        except AttributeError:
             player = None
     if game is None and player is not None:
         try:
             game = getattr(player, "game", None)
-        except Exception:
+        except AttributeError:
             game = None
 
     sr = getattr(root, "special_rules", None)
@@ -42,7 +69,8 @@ def apply_flickering_reality_effect(
         sr = {}
     try:
         roll_val = int(roll)
-    except Exception:
+    except (TypeError, ValueError):
+        logger.warning("Invalid Flickering Reality roll %r; coercing to 0.", roll, exc_info=True)
         roll_val = int(roll or 0)
     sr["flickering_reality_active"] = True
     sr["flickering_reality_hit_roll"] = roll_val
@@ -50,15 +78,16 @@ def apply_flickering_reality_effect(
     try:
         sr["flickering_reality_turn_owner"] = str(getattr(player, "id", "") or "")
         sr["flickering_reality_turn"] = int(getattr(game, "turn", 0) or 0) if game is not None else 0
-    except Exception:
-        pass
+    except (TypeError, ValueError, AttributeError):
+        logger.warning("Failed to annotate Flickering Reality timing metadata.", exc_info=True)
     sr["flickering_reality_source"] = str(source or "Flickering Reality").strip() or "Flickering Reality"
     root.special_rules = sr
+    _bump_effect_generation(root, "active_rule_effect_changed", player=player, game=game)
     if player is not None:
         try:
             append_action(player, f"{root.name}: Flickering Reality active (hits on {roll_val} end attacks).")
-        except Exception:
-            pass
+        except (AttributeError, TypeError):
+            logger.warning("Failed to append Flickering Reality action log.", exc_info=True)
     return root
 
 
@@ -78,12 +107,12 @@ def apply_pyrogenesis_effect(
     if player is None:
         try:
             player = root.get_parent_army().player
-        except Exception:
+        except AttributeError:
             player = None
     if game is None and player is not None:
         try:
             game = getattr(player, "game", None)
-        except Exception:
+        except AttributeError:
             game = None
 
     sr = getattr(root, "special_rules", None)
@@ -91,11 +120,13 @@ def apply_pyrogenesis_effect(
         sr = {}
     try:
         s_bonus = int(strength_bonus)
-    except Exception:
+    except (TypeError, ValueError):
+        logger.warning("Invalid Pyrogenesis strength bonus %r; coercing to 0.", strength_bonus, exc_info=True)
         s_bonus = int(strength_bonus or 0)
     try:
         a_bonus = int(ap_bonus)
-    except Exception:
+    except (TypeError, ValueError):
+        logger.warning("Invalid Pyrogenesis AP bonus %r; coercing to 0.", ap_bonus, exc_info=True)
         a_bonus = int(ap_bonus or 0)
     sr["pyrogenesis_active"] = True
     sr["pyrogenesis_strength_bonus"] = s_bonus
@@ -104,16 +135,17 @@ def apply_pyrogenesis_effect(
     try:
         sr["pyrogenesis_turn_owner"] = str(getattr(player, "id", "") or "")
         sr["pyrogenesis_turn"] = int(getattr(game, "turn", 0) or 0) if game is not None else 0
-    except Exception:
-        pass
+    except (TypeError, ValueError, AttributeError):
+        logger.warning("Failed to annotate Pyrogenesis timing metadata.", exc_info=True)
     sr["pyrogenesis_source"] = str(source or "Pyrogenesis").strip() or "Pyrogenesis"
     root.special_rules = sr
+    _bump_effect_generation(root, "active_rule_effect_changed", player=player, game=game)
     if player is not None:
         try:
             if a_bonus:
                 append_action(player, f"{root.name}: Pyrogenesis active (+{s_bonus}S, AP improved by {a_bonus}).")
             else:
                 append_action(player, f"{root.name}: Pyrogenesis active (+{s_bonus}S).")
-        except Exception:
-            pass
+        except (AttributeError, TypeError):
+            logger.warning("Failed to append Pyrogenesis action log.", exc_info=True)
     return root

--- a/src/warhammer40k_ai/version.py
+++ b/src/warhammer40k_ai/version.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-APP_VERSION = "0.2.113"
+APP_VERSION = "0.2.114"
 __version__ = APP_VERSION
 
 

--- a/tests/battlefield/test_map_state_generation.py
+++ b/tests/battlefield/test_map_state_generation.py
@@ -3,6 +3,12 @@ from types import SimpleNamespace
 
 from warhammer40k_ai.battlefield.map import Map
 from warhammer40k_ai.battlefield.terrain_visibility import _visibility_context_cache_key
+from warhammer40k_ai.engine.phase import BattleRoundPhases
+from warhammer40k_ai.engine.turn_manager import next_phase
+from warhammer40k_ai.roster.player_resources import PlayerResourceMixin
+from warhammer40k_ai.units.model import Model
+from warhammer40k_ai.utility.model_base import Base, BaseType
+from warhammer40k_ai.utility.stratagem_effects import apply_pyrogenesis_effect
 
 
 def test_map_state_generation_bumps_and_clears_visibility_cache_on_mutation():
@@ -37,3 +43,76 @@ def test_visibility_context_cache_key_includes_map_generation():
     assert before != after
     assert before[1] == 0
     assert after[1] == 1
+
+
+def test_model_movement_and_wounds_bump_map_generation():
+    game_map = Map(width=60, height=44)
+    model = Model(
+        name="Test Model",
+        movement=6,
+        toughness=4,
+        save=3,
+        wounds=2,
+        leadership=7,
+        objective_control=1,
+        model_base=Base(BaseType.CIRCULAR, 1.0),
+    )
+    model.set_parent_unit(
+        SimpleNamespace(
+            get_parent_army=lambda: SimpleNamespace(player=SimpleNamespace(game=SimpleNamespace(map=game_map)))
+        )
+    )
+
+    assert game_map.state_generation == 0
+    model.set_location(1.0, 2.0, 0.0, 90.0)
+    model.wounds = 1
+    assert game_map.state_generation == 2
+
+
+class _DummyPlayer(PlayerResourceMixin):
+    def __init__(self, game):
+        self.game = game
+        self.cp_history = []
+        self.command_points = 0
+
+
+def test_cp_change_bumps_map_generation():
+    game_map = Map(width=60, height=44)
+    player = _DummyPlayer(SimpleNamespace(map=game_map, phase=BattleRoundPhases.COMMAND_PHASE, get_battle_round=lambda: 1))
+
+    player._record_cp_change(1, reason="test", source="test")
+
+    assert game_map.state_generation == 1
+
+
+def test_phase_change_bumps_map_generation():
+    game_map = Map(width=60, height=44)
+    player = SimpleNamespace(name="P1")
+    game = SimpleNamespace(
+        phase=BattleRoundPhases.COMMAND_PHASE,
+        map=game_map,
+        reinforcements_step_active=False,
+        event_system=SimpleNamespace(publish=lambda *_args, **_kwargs: None),
+        get_current_player=lambda: player,
+        current_player_index=0,
+        players=[SimpleNamespace(get_army=lambda: SimpleNamespace(units=[], on_battle_round_start=lambda _turn: None))],
+        battle_round_starting_player_index=None,
+        turn=1,
+        start_command_phase=lambda: None,
+        end_of_turn_scoring=lambda: None,
+        end_of_battle_round_scoring=lambda: None,
+    )
+
+    next_phase(game)
+    assert game_map.state_generation == 1
+
+
+def test_active_rule_effect_bumps_map_generation_from_explicit_game():
+    game_map = Map(width=60, height=44)
+    unit = SimpleNamespace(name="Rubric Marines", special_rules={})
+    game = SimpleNamespace(map=game_map, turn=1)
+    player = SimpleNamespace(id="p1", game=game, action_history=[])
+
+    apply_pyrogenesis_effect(unit, strength_bonus=1, ap_bonus=1, phase_key="shooting", player=player, game=game)
+
+    assert game_map.state_generation == 1

--- a/tests/units/test_parsed_datasheet_cache.py
+++ b/tests/units/test_parsed_datasheet_cache.py
@@ -1,0 +1,90 @@
+from warhammer40k_ai.units.unit import Unit
+
+
+class MockDatasheet:
+    def __init__(self, *, datasheet_id: str, model_name: str = "Test Model", models_cost=None):
+        self.id = datasheet_id
+        self.name = "Cached Unit"
+        self.faction_data = {"name": "Test Faction"}
+        self.faction_id = "test-faction"
+        self.keywords = ["INFANTRY"]
+        self.faction_keywords = ["TEST"]
+        self.datasheets_unit_composition = [{"description": f"1 {model_name}"}]
+        self.datasheets_models_cost = models_cost or [{"description": "1 models", "cost": 100}]
+        self.datasheets_models = [{
+            "name": model_name,
+            "M": "6",
+            "T": "4",
+            "Sv": "3",
+            "W": "1",
+            "Ld": "7",
+            "OC": "1",
+            "base_size": "32mm",
+            "inv_sv": "7",
+            "inv_sv_descr": "none",
+        }]
+        self.datasheets_wargear = []
+        self.datasheets_options = [{"description": "none"}]
+        self.datasheets_abilities = []
+        self.loadout = "This model is equipped with: nothing"
+
+
+def test_unit_reuses_cached_parsed_datasheet_record(monkeypatch):
+    datasheet = MockDatasheet(datasheet_id="cache-test-1")
+    first = Unit(datasheet)
+    assert first.unit_composition == {"Test Model": (1, 1)}
+    assert first.wargear_options == {}
+
+    def _should_not_run(_self, _datasheet):
+        raise AssertionError("Unexpected reparsing call for cached datasheet.")
+
+    monkeypatch.setattr(Unit, "_parse_abilities", _should_not_run)
+
+    second = Unit(datasheet)
+    assert second.unit_composition == {"Test Model": (1, 1)}
+    assert second.wargear_options == {}
+
+
+def test_cached_parsed_datasheet_record_does_not_share_mutable_unit_state():
+    datasheet = MockDatasheet(datasheet_id="cache-test-mutable")
+    first = Unit(datasheet)
+    first.unit_composition["Test Model"] = (9, 9)
+    first.keywords.append("MUTATED")
+
+    second = Unit(datasheet)
+
+    assert second.unit_composition == {"Test Model": (1, 1)}
+    assert second.keywords == ["INFANTRY"]
+
+
+def test_cached_parsed_datasheet_key_includes_static_payload_for_reused_ids():
+    first_datasheet = MockDatasheet(datasheet_id="cache-test-reused-id", model_name="First Model")
+    second_datasheet = MockDatasheet(datasheet_id="cache-test-reused-id", model_name="Second Model")
+
+    first = Unit(first_datasheet)
+    second = Unit(second_datasheet)
+
+    assert first.unit_composition == {"First Model": (1, 1)}
+    assert second.unit_composition == {"Second Model": (1, 1)}
+
+
+def test_cached_parsed_datasheet_record_preserves_model_cost_addons(monkeypatch):
+    datasheet = MockDatasheet(
+        datasheet_id="cache-test-addon-cost",
+        model_name="Attack Bike",
+        models_cost=[
+            {"description": "1 models", "cost": "100"},
+            {"description": "Attack Bike", "cost": "+55"},
+        ],
+    )
+    first = Unit(datasheet)
+    assert first.get_unit_cost() == 155
+
+    def _should_not_run(_self, _models_cost):
+        raise AssertionError("Unexpected model-cost reparsing call for cached datasheet.")
+
+    monkeypatch.setattr(Unit, "_parse_models_cost", _should_not_run)
+
+    second = Unit(datasheet)
+    assert second.models_cost_addons == {"attack bike": 55}
+    assert second.get_unit_cost() == 155


### PR DESCRIPTION
## Summary

- Add immutable parsed datasheet records for static unit construction data and wire Unit construction through a cloned parsed-datasheet cache.
- Preserve mutable battlefield state on Unit/Model while expanding Map state-generation invalidation for movement, wounds, destroyed models, phase/round changes, CP changes, and active rule effects.
- Replace targeted high-risk broad exception swallowing in Model, Wargear keyword suffix parsing, and stratagem effect application paths with narrower exception handling and telemetry.
- Add focused tests for cache reuse/isolation, reused datasheet IDs, model cost add-ons, and new state-generation triggers; update profiling docs.

## Validation

- `python3 -m compileall -q src tests`
- `PYTHONPATH=src python3 -m pytest -o addopts='' tests/units/test_parsed_datasheet_cache.py tests/battlefield/test_map_state_generation.py -q` -> 11 passed
- `PYTHONPATH=src python3 -m pytest tests/ -m "not slow and not integration and not ui" -q` -> 7354 passed
- `PYTHONPATH=src python3 -m pytest tests/ -q` -> 7555 passed

## Notes

This includes the prior cloud work plus the local continuation fixes found during full-suite validation, including cache key hardening for reused mock datasheet IDs and custom datasheet payload attributes.